### PR TITLE
修改添加mapSqlParameterSource策略

### DIFF
--- a/src/main/java/top/fastsql/SQL.java
+++ b/src/main/java/top/fastsql/SQL.java
@@ -3,8 +3,15 @@ package top.fastsql;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.*;
-import org.springframework.jdbc.core.namedparam.*;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.ColumnMapRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SingleColumnRowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.util.StringUtils;
 import top.fastsql.config.DataSourceType;
 import top.fastsql.dto.BatchUpdateResult;
@@ -18,12 +25,21 @@ import top.fastsql.util.PageUtils;
 import javax.sql.DataSource;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.sql.*;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -43,7 +59,7 @@ public class SQL {
 
     private boolean logSqlWhenBuild = false;
 
-    private SqlParameterSource sqlParameterSource = new EmptySqlParameterSource();
+    private final MapSqlParameterSource sqlParameterSource = new MapSqlParameterSource();
 
     private Object[] varParams;
 
@@ -652,8 +668,8 @@ public class SQL {
     }
 
 
-    public SQL parameter(SqlParameterSource sqlParameterSource) {
-        this.sqlParameterSource = sqlParameterSource;
+    public SQL parameter(MapSqlParameterSource mapSqlParameterSource) {
+        this.sqlParameterSource.addValues(mapSqlParameterSource.getValues());
         return this;
     }
 
@@ -664,7 +680,7 @@ public class SQL {
      * @param mapParameter Map参数
      */
     public SQL mapParameter(Map<String, Object> mapParameter) {
-        this.sqlParameterSource = new MapSqlParameterSource(mapParameter);
+        this.sqlParameterSource.addValues(mapParameter);
         return this;
     }
 
@@ -674,83 +690,52 @@ public class SQL {
      * @param mapParameter 多个Map参数
      */
     public SQL mapParameter(Map<String, Object>... mapParameter) {
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
         for (Map<String, Object> map : mapParameter) {
-            mapSqlParameterSource.addValues(map);
+            this.sqlParameterSource.addValues(map);
         }
-        this.sqlParameterSource = mapSqlParameterSource;
         return this;
     }
 
 
     public SQL mapItemsParameter(String k1, Object v1) {
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-        mapSqlParameterSource.addValue(k1, v1);
-        this.sqlParameterSource = mapSqlParameterSource;
+        this.sqlParameterSource.addValue(k1, v1);
         return this;
     }
 
     public SQL mapItemsParameter(String k1, Object v1, String k2, Object v2) {
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-        mapSqlParameterSource.addValue(k1, v1);
-        mapSqlParameterSource.addValue(k2, v2);
-        this.sqlParameterSource = mapSqlParameterSource;
+        this.sqlParameterSource.addValue(k1, v1);
+        this.sqlParameterSource.addValue(k2, v2);
         return this;
     }
 
     public SQL mapItemsParameter(String k1, Object v1, String k2, Object v2, String k3, Object v3) {
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-        mapSqlParameterSource.addValue(k1, v1);
-        mapSqlParameterSource.addValue(k2, v2);
-        mapSqlParameterSource.addValue(k3, v3);
-        this.sqlParameterSource = mapSqlParameterSource;
+        this.sqlParameterSource.addValue(k1, v1);
+        this.sqlParameterSource.addValue(k2, v2);
+        this.sqlParameterSource.addValue(k3, v3);
         return this;
     }
 
     public SQL mapItemsParameter(String k1, Object v1, String k2, Object v2, String k3, Object v3, String k4, Object v4) {
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-        mapSqlParameterSource.addValue(k1, v1);
-        mapSqlParameterSource.addValue(k2, v2);
-        mapSqlParameterSource.addValue(k3, v3);
-        mapSqlParameterSource.addValue(k4, v4);
-        this.sqlParameterSource = mapSqlParameterSource;
+        this.sqlParameterSource.addValue(k1, v1);
+        this.sqlParameterSource.addValue(k2, v2);
+        this.sqlParameterSource.addValue(k3, v3);
+        this.sqlParameterSource.addValue(k4, v4);
         return this;
     }
 
     public SQL mapItemsParameter(String k1, Object v1, String k2, Object v2, String k3, Object v3, String k4, Object v4, String k5, Object v5) {
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-        mapSqlParameterSource.addValue(k1, v1);
-        mapSqlParameterSource.addValue(k2, v2);
-        mapSqlParameterSource.addValue(k3, v3);
-        mapSqlParameterSource.addValue(k4, v4);
-        mapSqlParameterSource.addValue(k5, v5);
-        this.sqlParameterSource = mapSqlParameterSource;
+        this.sqlParameterSource.addValue(k1, v1);
+        this.sqlParameterSource.addValue(k2, v2);
+        this.sqlParameterSource.addValue(k3, v3);
+        this.sqlParameterSource.addValue(k4, v4);
+        this.sqlParameterSource.addValue(k5, v5);
         return this;
     }
 
 
     public SQL addMapParameterItem(String key, Object value) {
-        if (this.sqlParameterSource instanceof EmptySqlParameterSource) {
-            //新建一个MapSqlParameterSource
-            this.sqlParameterSource = new MapSqlParameterSource(key, value);
-        } else if (this.sqlParameterSource instanceof BeanPropertySqlParameterSource) {
-            BeanPropertySqlParameterSource propertySqlParameterSource = (BeanPropertySqlParameterSource) this.sqlParameterSource;
-
-            MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-            //TODO propertySqlParameterSource.getReadablePropertyNames 多了class属性
-            for (String name : propertySqlParameterSource.getReadablePropertyNames()) {
-                mapSqlParameterSource.addValue(name, propertySqlParameterSource.getValue(name));
-            }
-            //add
-            mapSqlParameterSource.addValue(key, value);
-            this.sqlParameterSource = mapSqlParameterSource;
-        } else if (this.sqlParameterSource instanceof MapSqlParameterSource) {
-            ((MapSqlParameterSource) this.sqlParameterSource).addValue(key, value);
-        } else {
-            throw new RuntimeException("当前参数不支持addParameterMapItem");
-        }
+        this.sqlParameterSource.addValue(key, value);
         return this;
-
     }
 
     public SQL appendMapParameterItem(String key, Object value) {
@@ -758,30 +743,21 @@ public class SQL {
     }
 
 
-    /**
-     * 出现相同名称的参数时，map或覆盖bean中的参数
-     *
-     * @param bean bean
-     * @param map  map
-     */
     public SQL beanAndMapParameter(Object bean, Map<String, Object> map) {
-        BeanPropertySqlParameterSource propertySqlParameterSource = new BeanPropertySqlParameterSource(bean);
-
-        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
-
-        for (String name : propertySqlParameterSource.getReadablePropertyNames()) {
-            mapSqlParameterSource.addValue(name, propertySqlParameterSource.getValue(name));
-        }
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            mapSqlParameterSource.addValue(entry.getKey(), entry.getValue());
-        }
-        this.sqlParameterSource = mapSqlParameterSource;
+        this.beanParameter(bean);
+        this.sqlParameterSource.addValues(map);
         return this;
     }
 
 
     public SQL beanParameter(Object beanParam) {
-        this.sqlParameterSource = new BeanPropertySqlParameterSource(beanParam);
+        final BeanPropertySqlParameterSource propertySqlParameterSource
+                = new BeanPropertySqlParameterSource(beanParam);
+
+        for (String name : propertySqlParameterSource.getReadablePropertyNames()) {
+            this.sqlParameterSource.addValue(name, propertySqlParameterSource.getValue(name));
+        }
+
         return this;
     }
 

--- a/src/main/java/top/fastsql/dao/BaseDAO.java
+++ b/src/main/java/top/fastsql/dao/BaseDAO.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.util.StringUtils;
 import top.fastsql.SQL;
 import top.fastsql.SQLFactory;
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -349,7 +350,7 @@ public abstract class BaseDAO<E, ID> {
     /**
      * 根据id列表批量删除数据
      */
-    public BatchUpdateResult deleteInBatch(List<ID> ids) {
+    public BatchUpdateResult deleteInBatch(Collection<ID> ids) {
         final String sql = "DELETE FROM " + tableName + " WHERE " + idColumnName + "=:" + idColumnName;
 
         List<Map<String, Object>> mapList = new ArrayList<>(ids.size());
@@ -409,7 +410,7 @@ public abstract class BaseDAO<E, ID> {
         }
     }
 
-    public E selectOneWhere(String sqlCondition, SqlParameterSource parameterSource) {
+    public E selectOneWhere(String sqlCondition, MapSqlParameterSource parameterSource) {
         //sql
         String sql = "SELECT * FROM " + tableName + " WHERE " + sqlCondition;
 
@@ -440,7 +441,7 @@ public abstract class BaseDAO<E, ID> {
         return getSQL().useSql(sql).varParameter(values).queryList(new BeanPropertyRowMapper<>(entityClass));
     }
 
-    public List<E> selectWhere(String sqlCondition, SqlParameterSource parameterSource) {
+    public List<E> selectWhere(String sqlCondition, MapSqlParameterSource parameterSource) {
         //sql
         String sql = "SELECT * FROM " + tableName + " WHERE " + sqlCondition;
         return getSQL().useSql(sql).parameter(parameterSource).queryList(new BeanPropertyRowMapper<>(entityClass));
@@ -452,7 +453,7 @@ public abstract class BaseDAO<E, ID> {
         return getSQL().useSql(sql).varParameter(values).queryInteger();
     }
 
-    public int countWhere(String sqlCondition, SqlParameterSource parameterSource) {
+    public int countWhere(String sqlCondition, MapSqlParameterSource parameterSource) {
         //sql
         String sql = "SELECT count(*) FROM " + tableName + " WHERE " + sqlCondition;
         return getSQL().useSql(sql).parameter(parameterSource).queryInteger();
@@ -471,7 +472,7 @@ public abstract class BaseDAO<E, ID> {
     }
 
     public ResultPage<E> selectPageWhere(String sqlCondition, int pageNumber, int perPage,
-                                         SqlParameterSource parameterSource) {
+                                         MapSqlParameterSource parameterSource) {
         String sql = "SELECT * FROM " + tableName + " WHERE 1=1 AND " + sqlCondition;
         return getSQL().useSql(sql).parameter(parameterSource)
                 .queryPage(pageNumber, perPage, new BeanPropertyRowMapper<>(entityClass));


### PR DESCRIPTION
窄化`top.fastsql.SQL#sqlParameterSource`为final的`MapSqlParameterSource`实例。
在后续的添加参数方法中，将传入的参数加入到该实例中，避免运行时异常抛出导致操作失败。